### PR TITLE
Only generate relationships between chains

### DIFF
--- a/dotiptables/dotiptables.py
+++ b/dotiptables/dotiptables.py
@@ -38,6 +38,7 @@ re_commit=re.compile(re_commit)
 re_comment='''^#(?P<comment>.*)'''
 re_comment=re.compile(re_comment)
 
+
 def parse_args():
     p = argparse.ArgumentParser()
     p.add_argument('--outputdir', '-d', default='.')
@@ -69,7 +70,7 @@ def handle_rule(iptables, mo, line):
     fields = dict( (k, v if v else '') for k,v in mo.groupdict().items())
     iptables['_table'][fields['chain']]['rules'].append(fields)
 
-    if mo.group('target') and mo.group('target') not in BUILTIN_CHAINS:
+    if mo.group('target') and mo.group('target') in iptables['_table']:
         iptables['_table'][fields['chain']]['targets'].add(mo.group('target'))
 
 def handle_commit(iptables, mo, line):


### PR DESCRIPTION
When evaluating the argument to the iptables `-j` option, only add a
new relationship if the target of `-j` is actually a chain.

Closes #3